### PR TITLE
Add Prettier Pre-Hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 6
+script: yarn && yarn test && yarn compile

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
     "name": "redux-taxi",
     "version": "1.2.0",
-    "description":
-        "Inform server-side rendering from the component level when dealing with asynchronous actions.",
+    "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
     "main": "lib/index",
     "scripts": {
         "compile": "rm -rf ./lib && babel -d lib/ src/",
         "prepublish": "npm run test && npm run compile",
         "test": "jest",
-        "precommit": "lint-staged"
     },
     "repository": "NYTimes/redux-taxi",
     "keywords": [
@@ -43,18 +41,9 @@
         "babel-preset-react": "^6.5.0",
         "babel-preset-stage-0": "^6.5.0",
         "babel-register": "^6.7.2",
-        "husky": "^0.14.3",
         "jest": "^21.2.1",
-        "lint-staged": "^4.2.3",
-        "prettier": "^1.7.4",
         "prop-types": "^15.5.8",
         "react": "^15.5.4",
         "react-dom": "^15.5.4"
-    },
-    "lint-staged": {
-        "*.{js,json}": [
-            "prettier --write --trailing-comma es5 --single-quote --tab-width 4",
-            "git add"
-        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,50 +1,51 @@
 {
-    "name": "redux-taxi",
-    "version": "1.2.0",
-    "description":
-        "Inform server-side rendering from the component level when dealing with asynchronous actions.",
-    "main": "lib/index",
-    "scripts": {
-        "compile": "rm -rf ./lib && babel -d lib/ src/",
-        "prepublish": "npm run test && npm run compile",
-        "test": "jest"
-    },
-    "repository": "NYTimes/redux-taxi",
-    "keywords": [
-        "redux",
-        "react",
-        "taxi",
-        "server rendering",
-        "ssr",
-        "isomorphic",
-        "universal",
-        "nytimes"
-    ],
-    "author": "Jeremy Gayed (https://github.com/tizmagik)",
-    "contributors": [
-        "Ivan Kravchenko (https://github.com/ivankravchenko)",
-        "Devorah Moskowitz (https://github.com/devorah)",
-        "Oleh Ziniak (https://github.com/oziniak)"
-    ],
-    "license": "Apache 2.0",
-    "bugs": {
-        "url": "https://github.com/NYTimes/redux-taxi/issues"
-    },
-    "homepage": "https://github.com/NYTimes/redux-taxi#readme",
-    "devDependencies": {
-        "babel-cli": "^6.6.5",
-        "babel-core": "^6.7.4",
-        "babel-jest": "^21.2.0",
-        "babel-plugin-transform-decorators-legacy": "^1.3.4",
-        "babel-plugin-transform-runtime": "^6.6.0",
-        "babel-polyfill": "^6.7.4",
-        "babel-preset-es2015": "^6.6.0",
-        "babel-preset-react": "^6.5.0",
-        "babel-preset-stage-0": "^6.5.0",
-        "babel-register": "^6.7.2",
-        "jest": "^21.2.1",
-        "prop-types": "^15.5.8",
-        "react": "^15.5.4",
-        "react-dom": "^15.5.4"
-    }
+  "name": "redux-taxi",
+  "version": "1.2.0",
+  "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
+  "main": "lib/index",
+  "scripts": {
+    "compile": "rm -rf ./lib && babel -d lib/ src/",
+    "prepublish": "npm run test && npm run compile",
+    "test": "jest"
+  },
+  "repository": "NYTimes/redux-taxi",
+  "keywords": [
+    "redux",
+    "react",
+    "taxi",
+    "server rendering",
+    "ssr",
+    "isomorphic",
+    "universal",
+    "nytimes"
+  ],
+  "author": "Jeremy Gayed (https://github.com/tizmagik)",
+  "contributors": [
+    "Ivan Kravchenko (https://github.com/ivankravchenko)",
+    "Devorah Moskowitz (https://github.com/devorah)",
+    "Oleh Ziniak (https://github.com/oziniak)"
+  ],
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/NYTimes/redux-taxi/issues"
+  },
+  "homepage": "https://github.com/NYTimes/redux-taxi#readme",
+  "devDependencies": {
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.4",
+    "babel-jest": "^21.2.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-polyfill": "^6.7.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.7.2",
+    "chai": "^3.5.0",
+    "jest": "^21.2.1",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "sinon": "^1.17.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
     "name": "redux-taxi",
     "version": "1.2.0",
-    "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
+    "description":
+        "Inform server-side rendering from the component level when dealing with asynchronous actions.",
     "main": "lib/index",
     "scripts": {
         "compile": "rm -rf ./lib && babel -d lib/ src/",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "compile": "rm -rf ./lib && babel -d lib/ src/",
         "prepublish": "npm run test && npm run compile",
-        "test": "jest",
+        "test": "jest"
     },
     "repository": "NYTimes/redux-taxi",
     "keywords": [
@@ -45,5 +45,10 @@
         "prop-types": "^15.5.8",
         "react": "^15.5.4",
         "react-dom": "^15.5.4"
+    },
+    "dependencies": {
+        "husky": "^0.14.3",
+        "lint-staged": "^4.2.3",
+        "prettier": "^1.7.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,60 +1,61 @@
 {
-  "name": "redux-taxi",
-  "version": "1.2.0",
-  "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
-  "main": "lib/index",
-  "scripts": {
-    "compile": "rm -rf ./lib && babel -d lib/ src/",
-    "prepublish": "npm run test && npm run compile",
-    "test": "jest",
-    "precommit": "lint-staged"
-  },
-  "repository": "NYTimes/redux-taxi",
-  "keywords": [
-    "redux",
-    "react",
-    "taxi",
-    "server rendering",
-    "ssr",
-    "isomorphic",
-    "universal",
-    "nytimes"
-  ],
-  "author": "Jeremy Gayed (https://github.com/tizmagik)",
-  "contributors": [
-    "Ivan Kravchenko (https://github.com/ivankravchenko)",
-    "Devorah Moskowitz (https://github.com/devorah)",
-    "Oleh Ziniak (https://github.com/oziniak)"
-  ],
-  "license": "Apache 2.0",
-  "bugs": {
-    "url": "https://github.com/NYTimes/redux-taxi/issues"
-  },
-  "homepage": "https://github.com/NYTimes/redux-taxi#readme",
-  "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.7.4",
-    "babel-jest": "^21.2.0",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-runtime": "^6.6.0",
-    "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.7.2",
-    "husky": "^0.14.3",
-    "jest": "^21.2.1",
-    "lint-staged": "^4.2.3",
-    "prettier": "^1.7.4",
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "sinon": "^1.17.3"
-  },
-  "lint-staged": {
-    "*.js": [
-      "prettier --write --trailing-comma es5 --single-quote --tab-width 4",
-      "git add"
-    ]
-  }
+    "name": "redux-taxi",
+    "version": "1.2.0",
+    "description":
+        "Inform server-side rendering from the component level when dealing with asynchronous actions.",
+    "main": "lib/index",
+    "scripts": {
+        "compile": "rm -rf ./lib && babel -d lib/ src/",
+        "prepublish": "npm run test && npm run compile",
+        "test": "jest",
+        "precommit": "lint-staged"
+    },
+    "repository": "NYTimes/redux-taxi",
+    "keywords": [
+        "redux",
+        "react",
+        "taxi",
+        "server rendering",
+        "ssr",
+        "isomorphic",
+        "universal",
+        "nytimes"
+    ],
+    "author": "Jeremy Gayed (https://github.com/tizmagik)",
+    "contributors": [
+        "Ivan Kravchenko (https://github.com/ivankravchenko)",
+        "Devorah Moskowitz (https://github.com/devorah)",
+        "Oleh Ziniak (https://github.com/oziniak)"
+    ],
+    "license": "Apache 2.0",
+    "bugs": {
+        "url": "https://github.com/NYTimes/redux-taxi/issues"
+    },
+    "homepage": "https://github.com/NYTimes/redux-taxi#readme",
+    "devDependencies": {
+        "babel-cli": "^6.6.5",
+        "babel-core": "^6.7.4",
+        "babel-jest": "^21.2.0",
+        "babel-plugin-transform-decorators-legacy": "^1.3.4",
+        "babel-plugin-transform-runtime": "^6.6.0",
+        "babel-polyfill": "^6.7.4",
+        "babel-preset-es2015": "^6.6.0",
+        "babel-preset-react": "^6.5.0",
+        "babel-preset-stage-0": "^6.5.0",
+        "babel-register": "^6.7.2",
+        "husky": "^0.14.3",
+        "jest": "^21.2.1",
+        "lint-staged": "^4.2.3",
+        "prettier": "^1.7.4",
+        "prop-types": "^15.5.8",
+        "react": "^15.5.4",
+        "react-dom": "^15.5.4",
+        "sinon": "^1.17.3"
+    },
+    "lint-staged": {
+        "*.{js,json}": [
+            "prettier --write --trailing-comma es5 --single-quote --tab-width 4",
+            "git add"
+        ]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
-    "chai": "^3.5.0",
     "jest": "^21.2.1",
     "prop-types": "^15.5.8",
     "react": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -1,51 +1,49 @@
 {
-  "name": "redux-taxi",
-  "version": "1.2.0",
-  "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
-  "main": "lib/index",
-  "scripts": {
-    "compile": "rm -rf ./lib && babel -d lib/ src/",
-    "prepublish": "npm run test && npm run compile",
-    "test": "jest"
-  },
-  "repository": "NYTimes/redux-taxi",
-  "keywords": [
-    "redux",
-    "react",
-    "taxi",
-    "server rendering",
-    "ssr",
-    "isomorphic",
-    "universal",
-    "nytimes"
-  ],
-  "author": "Jeremy Gayed (https://github.com/tizmagik)",
-  "contributors": [
-    "Ivan Kravchenko (https://github.com/ivankravchenko)",
-    "Devorah Moskowitz (https://github.com/devorah)",
-    "Oleh Ziniak (https://github.com/oziniak)"
-  ],
-  "license": "Apache 2.0",
-  "bugs": {
-    "url": "https://github.com/NYTimes/redux-taxi/issues"
-  },
-  "homepage": "https://github.com/NYTimes/redux-taxi#readme",
-  "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.7.4",
-    "babel-jest": "^21.2.0",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-runtime": "^6.6.0",
-    "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.7.2",
-    "chai": "^3.5.0",
-    "jest": "^21.2.1",
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "sinon": "^1.17.3"
-  }
+    "name": "redux-taxi",
+    "version": "1.2.0",
+    "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
+    "main": "lib/index",
+    "scripts": {
+        "compile": "rm -rf ./lib && babel -d lib/ src/",
+        "prepublish": "npm run test && npm run compile",
+        "test": "jest"
+    },
+    "repository": "NYTimes/redux-taxi",
+    "keywords": [
+        "redux",
+        "react",
+        "taxi",
+        "server rendering",
+        "ssr",
+        "isomorphic",
+        "universal",
+        "nytimes"
+    ],
+    "author": "Jeremy Gayed (https://github.com/tizmagik)",
+    "contributors": [
+        "Ivan Kravchenko (https://github.com/ivankravchenko)",
+        "Devorah Moskowitz (https://github.com/devorah)",
+        "Oleh Ziniak (https://github.com/oziniak)"
+    ],
+    "license": "Apache 2.0",
+    "bugs": {
+        "url": "https://github.com/NYTimes/redux-taxi/issues"
+    },
+    "homepage": "https://github.com/NYTimes/redux-taxi#readme",
+    "devDependencies": {
+        "babel-cli": "^6.6.5",
+        "babel-core": "^6.7.4",
+        "babel-jest": "^21.2.0",
+        "babel-plugin-transform-decorators-legacy": "^1.3.4",
+        "babel-plugin-transform-runtime": "^6.6.0",
+        "babel-polyfill": "^6.7.4",
+        "babel-preset-es2015": "^6.6.0",
+        "babel-preset-react": "^6.5.0",
+        "babel-preset-stage-0": "^6.5.0",
+        "babel-register": "^6.7.2",
+        "jest": "^21.2.1",
+        "prop-types": "^15.5.8",
+        "react": "^15.5.4",
+        "react-dom": "^15.5.4"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "compile": "rm -rf ./lib && babel -d lib/ src/",
     "prepublish": "npm run test && npm run compile",
-    "test": "jest"
+    "test": "jest",
+    "precommit": "lint-staged"
   },
   "repository": "NYTimes/redux-taxi",
   "keywords": [
@@ -41,10 +42,18 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
+    "husky": "^0.14.3",
     "jest": "^21.2.1",
+    "lint-staged": "^4.2.3",
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "sinon": "^1.17.3"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write --trailing-comma es5 --single-quote --tab-width 4",
+      "git add"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
         "prettier": "^1.7.4",
         "prop-types": "^15.5.8",
         "react": "^15.5.4",
-        "react-dom": "^15.5.4",
-        "sinon": "^1.17.3"
+        "react-dom": "^15.5.4"
     },
     "lint-staged": {
         "*.{js,json}": [

--- a/package.json
+++ b/package.json
@@ -1,54 +1,60 @@
 {
-    "name": "redux-taxi",
-    "version": "1.2.0",
-    "description": "Inform server-side rendering from the component level when dealing with asynchronous actions.",
-    "main": "lib/index",
-    "scripts": {
-        "compile": "rm -rf ./lib && babel -d lib/ src/",
-        "prepublish": "npm run test && npm run compile",
-        "test": "jest"
-    },
-    "repository": "NYTimes/redux-taxi",
-    "keywords": [
-        "redux",
-        "react",
-        "taxi",
-        "server rendering",
-        "ssr",
-        "isomorphic",
-        "universal",
-        "nytimes"
-    ],
-    "author": "Jeremy Gayed (https://github.com/tizmagik)",
-    "contributors": [
-        "Ivan Kravchenko (https://github.com/ivankravchenko)",
-        "Devorah Moskowitz (https://github.com/devorah)",
-        "Oleh Ziniak (https://github.com/oziniak)"
-    ],
-    "license": "Apache 2.0",
-    "bugs": {
-        "url": "https://github.com/NYTimes/redux-taxi/issues"
-    },
-    "homepage": "https://github.com/NYTimes/redux-taxi#readme",
-    "devDependencies": {
-        "babel-cli": "^6.6.5",
-        "babel-core": "^6.7.4",
-        "babel-jest": "^21.2.0",
-        "babel-plugin-transform-decorators-legacy": "^1.3.4",
-        "babel-plugin-transform-runtime": "^6.6.0",
-        "babel-polyfill": "^6.7.4",
-        "babel-preset-es2015": "^6.6.0",
-        "babel-preset-react": "^6.5.0",
-        "babel-preset-stage-0": "^6.5.0",
-        "babel-register": "^6.7.2",
-        "jest": "^21.2.1",
-        "prop-types": "^15.5.8",
-        "react": "^15.5.4",
-        "react-dom": "^15.5.4"
-    },
-    "dependencies": {
-        "husky": "^0.14.3",
-        "lint-staged": "^4.2.3",
-        "prettier": "^1.7.4"
-    }
+  "name": "redux-taxi",
+  "version": "1.2.0",
+  "description":
+    "Inform server-side rendering from the component level when dealing with asynchronous actions.",
+  "main": "lib/index",
+  "scripts": {
+    "compile": "rm -rf ./lib && babel -d lib/ src/",
+    "prepublish": "npm run test && npm run compile",
+    "test": "jest",
+    "precommit": "lint-staged"
+  },
+  "repository": "NYTimes/redux-taxi",
+  "keywords": [
+    "redux",
+    "react",
+    "taxi",
+    "server rendering",
+    "ssr",
+    "isomorphic",
+    "universal",
+    "nytimes"
+  ],
+  "author": "Jeremy Gayed (https://github.com/tizmagik)",
+  "contributors": [
+    "Ivan Kravchenko (https://github.com/ivankravchenko)",
+    "Devorah Moskowitz (https://github.com/devorah)",
+    "Oleh Ziniak (https://github.com/oziniak)"
+  ],
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/NYTimes/redux-taxi/issues"
+  },
+  "homepage": "https://github.com/NYTimes/redux-taxi#readme",
+  "devDependencies": {
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.4",
+    "babel-jest": "^21.2.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-polyfill": "^6.7.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.7.2",
+    "husky": "^0.14.3",
+    "jest": "^21.2.1",
+    "lint-staged": "^4.2.3",
+    "prettier": "^1.7.4",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
+  },
+  "lint-staged": {
+    "*.{js,json}": [
+      "prettier --write --trailing-comma es5 --single-quote --tab-width 2",
+      "git add"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "husky": "^0.14.3",
     "jest": "^21.2.1",
     "lint-staged": "^4.2.3",
+    "prettier": "^1.7.4",
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/src/PromiseMiddleware.js
+++ b/src/PromiseMiddleware.js
@@ -16,27 +16,29 @@ export const START = 'START';
 export const DONE = 'DONE';
 
 function generateRandomId() {
-    return Math.random().toString(36).slice(-5);
+    return Math.random()
+        .toString(36)
+        .slice(-5);
 }
 
 function sequence(id, type) {
     return {
-        sequence: {id, type}
+        sequence: { id, type },
     };
 }
 
 export default function PromiseMiddleware() {
     return next => action => {
-        const {promise, ...rest} = action;
+        const { promise, ...rest } = action;
         const id = generateRandomId();
 
         if (!promise) {
             return next(action);
         }
 
-        next({...rest, ...sequence(id, START)});
+        next({ ...rest, ...sequence(id, START) });
         return promise.then(
-            payload => next({...rest, payload, ...sequence(id, DONE)}),
+            payload => next({ ...rest, payload, ...sequence(id, DONE) }),
             reason => {
                 let error = reason;
                 // By FSA definition, payload SHOULD be an error object
@@ -44,12 +46,13 @@ export default function PromiseMiddleware() {
                 if (!(error instanceof Error)) {
                     let message = reason;
                     if (typeof message !== 'string') {
-                        message = 'Promise rejected with data. See error.data field.';
+                        message =
+                            'Promise rejected with data. See error.data field.';
                     }
                     error = new Error(message);
                     error.data = reason;
                 }
-                next({...rest, payload: error, error: true, ...sequence(id)});
+                next({ ...rest, payload: error, error: true, ...sequence(id) });
                 return Promise.reject(reason); // Don't break the promise chain
             }
         );

--- a/src/ReduxTaxi.js
+++ b/src/ReduxTaxi.js
@@ -28,6 +28,6 @@ export default function ReduxTaxi() {
 
         getAllPromises() {
             return promises;
-        }
+        },
     };
 }

--- a/src/ReduxTaxi.js
+++ b/src/ReduxTaxi.js
@@ -6,28 +6,28 @@
 **/
 
 export default function ReduxTaxi() {
-    const registeredActions = new Set();
-    const promises = [];
+  const registeredActions = new Set();
+  const promises = [];
 
-    return {
-        register(actionType) {
-            registeredActions.add(actionType);
-        },
+  return {
+    register(actionType) {
+      registeredActions.add(actionType);
+    },
 
-        getRegisteredActions() {
-            return registeredActions;
-        },
+    getRegisteredActions() {
+      return registeredActions;
+    },
 
-        isRegistered(actionType) {
-            return registeredActions.has(actionType);
-        },
+    isRegistered(actionType) {
+      return registeredActions.has(actionType);
+    },
 
-        collectPromise(promise) {
-            promises.push(promise);
-        },
+    collectPromise(promise) {
+      promises.push(promise);
+    },
 
-        getAllPromises() {
-            return promises;
-        },
-    };
+    getAllPromises() {
+      return promises;
+    },
+  };
 }

--- a/src/ReduxTaxiMiddleware.js
+++ b/src/ReduxTaxiMiddleware.js
@@ -16,18 +16,18 @@
 *
 **/
 export default function ReduxTaxiMiddleware(reduxTaxi) {
-    return () => next => action => {
-        const { promise, type } = action;
+  return () => next => action => {
+    const { promise, type } = action;
 
-        if (!promise) {
-            return next(action);
-        }
+    if (!promise) {
+      return next(action);
+    }
 
-        if (reduxTaxi.isRegistered(type)) {
-            reduxTaxi.collectPromise(promise);
-        } else {
-            throw new Error(
-                `The async action ${type} was dispatched in a server context without being explicitly registered.
+    if (reduxTaxi.isRegistered(type)) {
+      reduxTaxi.collectPromise(promise);
+    } else {
+      throw new Error(
+        `The async action ${type} was dispatched in a server context without being explicitly registered.
 
 This usually means an asynchronous action (an action that contains a Promise) was dispatched in a component's instantiation.
 
@@ -37,9 +37,9 @@ If you DO want to delay the pageload rendering and wait for the action to resolv
     Like so:
     @registerAsyncActions(${type})
 `
-            );
-        }
+      );
+    }
 
-        return next(action);
-    };
+    return next(action);
+  };
 }

--- a/src/ReduxTaxiMiddleware.js
+++ b/src/ReduxTaxiMiddleware.js
@@ -17,7 +17,7 @@
 **/
 export default function ReduxTaxiMiddleware(reduxTaxi) {
     return () => next => action => {
-        const {promise, type} = action;
+        const { promise, type } = action;
 
         if (!promise) {
             return next(action);
@@ -27,7 +27,7 @@ export default function ReduxTaxiMiddleware(reduxTaxi) {
             reduxTaxi.collectPromise(promise);
         } else {
             throw new Error(
-`The async action ${type} was dispatched in a server context without being explicitly registered.
+                `The async action ${type} was dispatched in a server context without being explicitly registered.
 
 This usually means an asynchronous action (an action that contains a Promise) was dispatched in a component's instantiation.
 

--- a/src/ReduxTaxiProvider.js
+++ b/src/ReduxTaxiProvider.js
@@ -1,24 +1,24 @@
-import React, {Component, Children} from 'react';
+import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 
 export default class ReduxTaxiProvider extends Component {
     static propTypes = {
         children: PropTypes.node.isRequired,
-        reduxTaxi: PropTypes.object.isRequired
+        reduxTaxi: PropTypes.object.isRequired,
     };
 
     static childContextTypes = {
-        reduxTaxi: PropTypes.object.isRequired
+        reduxTaxi: PropTypes.object.isRequired,
     };
 
     getChildContext() {
         return {
-            reduxTaxi: this.props.reduxTaxi
+            reduxTaxi: this.props.reduxTaxi,
         };
     }
 
     render() {
-        const {children} = this.props;
+        const { children } = this.props;
         return Children.only(children);
     }
 }

--- a/src/ReduxTaxiProvider.js
+++ b/src/ReduxTaxiProvider.js
@@ -2,23 +2,23 @@ import React, { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 
 export default class ReduxTaxiProvider extends Component {
-    static propTypes = {
-        children: PropTypes.node.isRequired,
-        reduxTaxi: PropTypes.object.isRequired,
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    reduxTaxi: PropTypes.object.isRequired,
+  };
+
+  static childContextTypes = {
+    reduxTaxi: PropTypes.object.isRequired,
+  };
+
+  getChildContext() {
+    return {
+      reduxTaxi: this.props.reduxTaxi,
     };
+  }
 
-    static childContextTypes = {
-        reduxTaxi: PropTypes.object.isRequired,
-    };
-
-    getChildContext() {
-        return {
-            reduxTaxi: this.props.reduxTaxi,
-        };
-    }
-
-    render() {
-        const { children } = this.props;
-        return Children.only(children);
-    }
+  render() {
+    const { children } = this.props;
+    return Children.only(children);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-export {default as ReduxTaxi} from './ReduxTaxi';
-export {default as ReduxTaxiMiddleware} from './ReduxTaxiMiddleware';
-export {default as ReduxTaxiProvider} from './ReduxTaxiProvider';
-export {default as registerAsyncActions} from './registerAsyncActions';
-export {default as PromiseMiddleware} from './PromiseMiddleware';
+export { default as ReduxTaxi } from './ReduxTaxi';
+export { default as ReduxTaxiMiddleware } from './ReduxTaxiMiddleware';
+export { default as ReduxTaxiProvider } from './ReduxTaxiProvider';
+export { default as registerAsyncActions } from './registerAsyncActions';
+export { default as PromiseMiddleware } from './PromiseMiddleware';

--- a/src/registerAsyncActions.js
+++ b/src/registerAsyncActions.js
@@ -11,23 +11,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default function registerAsyncActions(...actionTypes) {
-    return DecoratedComponent =>
-        class AsyncDecorator extends React.Component {
-            static contextTypes = {
-                reduxTaxi: PropTypes.object, // not required because we don't define it for client context
-            };
+  return DecoratedComponent =>
+    class AsyncDecorator extends React.Component {
+      static contextTypes = {
+        reduxTaxi: PropTypes.object, // not required because we don't define it for client context
+      };
 
-            constructor(props, context) {
-                super(props, context);
-                if (context.reduxTaxi) {
-                    actionTypes.forEach(actionType => {
-                        context.reduxTaxi.register(actionType);
-                    });
-                }
-            }
+      constructor(props, context) {
+        super(props, context);
+        if (context.reduxTaxi) {
+          actionTypes.forEach(actionType => {
+            context.reduxTaxi.register(actionType);
+          });
+        }
+      }
 
-            render() {
-                return <DecoratedComponent {...this.props} />;
-            }
-        };
+      render() {
+        return <DecoratedComponent {...this.props} />;
+      }
+    };
 }

--- a/src/registerAsyncActions.js
+++ b/src/registerAsyncActions.js
@@ -12,24 +12,22 @@ import PropTypes from 'prop-types';
 
 export default function registerAsyncActions(...actionTypes) {
     return DecoratedComponent =>
-    class AsyncDecorator extends React.Component {
-        static contextTypes = {
-            reduxTaxi: PropTypes.object // not required because we don't define it for client context
-        };
+        class AsyncDecorator extends React.Component {
+            static contextTypes = {
+                reduxTaxi: PropTypes.object, // not required because we don't define it for client context
+            };
 
-        constructor(props, context) {
-            super(props, context);
-            if (context.reduxTaxi) {
-                actionTypes.forEach(actionType => {
-                    context.reduxTaxi.register(actionType);
-                });
+            constructor(props, context) {
+                super(props, context);
+                if (context.reduxTaxi) {
+                    actionTypes.forEach(actionType => {
+                        context.reduxTaxi.register(actionType);
+                    });
+                }
             }
-        }
 
-        render() {
-            return (
-                <DecoratedComponent {...this.props} />
-            );
-        }
-    };
+            render() {
+                return <DecoratedComponent {...this.props} />;
+            }
+        };
 }

--- a/tests/PromiseMiddleware.test.js
+++ b/tests/PromiseMiddleware.test.js
@@ -1,149 +1,126 @@
 import PromiseMiddleware, { START, DONE } from '../src/PromiseMiddleware';
 
 describe('PromiseMiddleware', () => {
-    const nextHandler = PromiseMiddleware();
+  const nextHandler = PromiseMiddleware();
 
-    it('must return a function to handle next', () => {
-        expect(nextHandler).toBeInstanceOf(Function);
-        expect(nextHandler).toHaveLength(1);
+  it('must return a function to handle next', () => {
+    expect(nextHandler).toBeInstanceOf(Function);
+    expect(nextHandler).toHaveLength(1);
+  });
+
+  describe('handle next', () => {
+    it('must return a function to handle action', () => {
+      const actionHandler = nextHandler();
+
+      expect(actionHandler).toBeInstanceOf(Function);
+      expect(actionHandler).toHaveLength(1);
     });
 
-    describe('handle next', () => {
-        it('must return a function to handle action', () => {
-            const actionHandler = nextHandler();
+    describe('handle action', () => {
+      it('must pass actions without promises to the next handler', () => {
+        const actionObj = {};
+        const actionSpy = jest.fn();
+        const actionHandler = nextHandler(actionSpy);
 
-            expect(actionHandler).toBeInstanceOf(Function);
-            expect(actionHandler).toHaveLength(1);
+        actionHandler(actionObj);
+
+        expect(actionSpy).toHaveBeenCalledTimes(1);
+        expect(actionSpy).toHaveBeenCalledWith(actionObj);
+      });
+
+      describe('handle promise action', () => {
+        const promiseResolver = {};
+        const promiseResolverFn = (resolve, reject) => {
+          promiseResolver.resolve = resolve;
+          promiseResolver.reject = reject;
+        };
+
+        const promiseAction = {
+          type: 'test',
+          promise: new Promise(promiseResolverFn),
+        };
+
+        it('must produce a START sequenced action', () => {
+          const actionSpy = jest.fn();
+          const actionHandler = nextHandler(actionSpy);
+
+          actionHandler(promiseAction);
+
+          const { sequence, type } = actionSpy.mock.calls[0][0];
+
+          expect(actionSpy).toHaveBeenCalledTimes(1);
+          expect(sequence).toBeDefined();
+          expect(type).toEqual(promiseAction.type);
+          expect(sequence.type).toEqual(START);
         });
 
-        describe('handle action', () => {
-            it('must pass actions without promises to the next handler', () => {
-                const actionObj = {};
-                const actionSpy = jest.fn();
-                const actionHandler = nextHandler(actionSpy);
+        it('must produce a DONE sequenced action when the promise resolves', () => {
+          const actionSpy = jest.fn();
+          const actionHandler = nextHandler(actionSpy);
 
-                actionHandler(actionObj);
+          const promiseResult = actionHandler(promiseAction);
 
-                expect(actionSpy).toHaveBeenCalledTimes(1);
-                expect(actionSpy).toHaveBeenCalledWith(actionObj);
+          const firstCallArgs = actionSpy.mock.calls[0][0];
+          const { sequence: { id: expectedId } } = firstCallArgs;
+
+          expect(actionSpy).toHaveBeenCalledTimes(1);
+          expect(firstCallArgs).toHaveProperty('type', promiseAction.type);
+          expect(firstCallArgs).toHaveProperty('sequence');
+          expect(firstCallArgs.sequence).toHaveProperty('type', START);
+
+          promiseResolver.resolve();
+
+          return promiseResult.then(() => {
+            const secondCallArgs = actionSpy.mock.calls[1][0];
+
+            expect(actionSpy).toHaveBeenCalledTimes(2);
+            expect(secondCallArgs.sequence).toHaveProperty('id', expectedId);
+            expect(secondCallArgs.sequence).toHaveProperty('type', DONE);
+          });
+        });
+
+        it('must produce an ERROR action when the promise rejects', () => {
+          const actionSpy = jest.fn();
+          const actionHandler = nextHandler(actionSpy);
+
+          const promiseResult = actionHandler(promiseAction);
+
+          const firstCallArgs = actionSpy.mock.calls[0][0];
+          const { sequence: { id: expectedId } } = firstCallArgs;
+
+          expect(actionSpy).toHaveBeenCalledTimes(1);
+          expect(firstCallArgs).toHaveProperty('type', promiseAction.type);
+          expect(firstCallArgs).toHaveProperty('sequence');
+          expect(firstCallArgs.sequence).toHaveProperty('type', START);
+
+          promiseResolver.reject();
+
+          return promiseResult.catch(() => {
+            const secondCallArgs = actionSpy.mock.calls[1][0];
+
+            expect(actionSpy).toHaveBeenCalledTimes(2);
+            expect(secondCallArgs.sequence).toHaveProperty('id', expectedId);
+            expect(secondCallArgs.error).toBeTruthy();
+          });
+        });
+
+        it("must return a rejected promise when the action's promise rejects", () => {
+          const originalError = 'reason of failure';
+          const promiseActionToReject = {
+            type: 'test',
+            promise: Promise.reject(originalError),
+          };
+          const actionHandler = nextHandler(() => null);
+
+          return actionHandler(promiseActionToReject)
+            .then(() =>
+              fail('expected promise to be rejected, but was resolved')
+            )
+            .catch(error => {
+              expect(error).toEqual(originalError);
             });
-
-            describe('handle promise action', () => {
-                const promiseResolver = {};
-                const promiseResolverFn = (resolve, reject) => {
-                    promiseResolver.resolve = resolve;
-                    promiseResolver.reject = reject;
-                };
-
-                const promiseAction = {
-                    type: 'test',
-                    promise: new Promise(promiseResolverFn),
-                };
-
-                it('must produce a START sequenced action', () => {
-                    const actionSpy = jest.fn();
-                    const actionHandler = nextHandler(actionSpy);
-
-                    actionHandler(promiseAction);
-
-                    const { sequence, type } = actionSpy.mock.calls[0][0];
-
-                    expect(actionSpy).toHaveBeenCalledTimes(1);
-                    expect(sequence).toBeDefined();
-                    expect(type).toEqual(promiseAction.type);
-                    expect(sequence.type).toEqual(START);
-                });
-
-                it('must produce a DONE sequenced action when the promise resolves', () => {
-                    const actionSpy = jest.fn();
-                    const actionHandler = nextHandler(actionSpy);
-
-                    const promiseResult = actionHandler(promiseAction);
-
-                    const firstCallArgs = actionSpy.mock.calls[0][0];
-                    const { sequence: { id: expectedId } } = firstCallArgs;
-
-                    expect(actionSpy).toHaveBeenCalledTimes(1);
-                    expect(firstCallArgs).toHaveProperty(
-                        'type',
-                        promiseAction.type
-                    );
-                    expect(firstCallArgs).toHaveProperty('sequence');
-                    expect(firstCallArgs.sequence).toHaveProperty(
-                        'type',
-                        START
-                    );
-
-                    promiseResolver.resolve();
-
-                    return promiseResult.then(() => {
-                        const secondCallArgs = actionSpy.mock.calls[1][0];
-
-                        expect(actionSpy).toHaveBeenCalledTimes(2);
-                        expect(secondCallArgs.sequence).toHaveProperty(
-                            'id',
-                            expectedId
-                        );
-                        expect(secondCallArgs.sequence).toHaveProperty(
-                            'type',
-                            DONE
-                        );
-                    });
-                });
-
-                it('must produce an ERROR action when the promise rejects', () => {
-                    const actionSpy = jest.fn();
-                    const actionHandler = nextHandler(actionSpy);
-
-                    const promiseResult = actionHandler(promiseAction);
-
-                    const firstCallArgs = actionSpy.mock.calls[0][0];
-                    const { sequence: { id: expectedId } } = firstCallArgs;
-
-                    expect(actionSpy).toHaveBeenCalledTimes(1);
-                    expect(firstCallArgs).toHaveProperty(
-                        'type',
-                        promiseAction.type
-                    );
-                    expect(firstCallArgs).toHaveProperty('sequence');
-                    expect(firstCallArgs.sequence).toHaveProperty(
-                        'type',
-                        START
-                    );
-
-                    promiseResolver.reject();
-
-                    return promiseResult.catch(() => {
-                        const secondCallArgs = actionSpy.mock.calls[1][0];
-
-                        expect(actionSpy).toHaveBeenCalledTimes(2);
-                        expect(secondCallArgs.sequence).toHaveProperty(
-                            'id',
-                            expectedId
-                        );
-                        expect(secondCallArgs.error).toBeTruthy();
-                    });
-                });
-
-                it("must return a rejected promise when the action's promise rejects", () => {
-                    const originalError = 'reason of failure';
-                    const promiseActionToReject = {
-                        type: 'test',
-                        promise: Promise.reject(originalError),
-                    };
-                    const actionHandler = nextHandler(() => null);
-
-                    return actionHandler(promiseActionToReject)
-                        .then(() =>
-                            fail(
-                                'expected promise to be rejected, but was resolved'
-                            )
-                        )
-                        .catch(error => {
-                            expect(error).toEqual(originalError);
-                        });
-                });
-            }); // end describe('handle promise action')
-        }); // end describe('handle action')
-    }); // end describe('handle next')
+        });
+      }); // end describe('handle promise action')
+    }); // end describe('handle action')
+  }); // end describe('handle next')
 });

--- a/tests/ReduxTaxi.test.js
+++ b/tests/ReduxTaxi.test.js
@@ -1,60 +1,60 @@
 import { ReduxTaxi } from '../src/index';
 
 describe('ReduxTaxi', () => {
-    const actionType1 = 'test1';
-    const actionType2 = 'test2';
-    let reduxTaxi;
+  const actionType1 = 'test1';
+  const actionType2 = 'test2';
+  let reduxTaxi;
 
-    beforeEach(() => {
-        reduxTaxi = ReduxTaxi();
-    });
+  beforeEach(() => {
+    reduxTaxi = ReduxTaxi();
+  });
 
-    it('should correctly register an action', () => {
-        expect(reduxTaxi.getRegisteredActions().size).toEqual(0);
-        expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
-        expect(reduxTaxi.isRegistered(actionType2)).toBeFalsy();
+  it('should correctly register an action', () => {
+    expect(reduxTaxi.getRegisteredActions().size).toEqual(0);
+    expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
+    expect(reduxTaxi.isRegistered(actionType2)).toBeFalsy();
 
-        reduxTaxi.register(actionType1);
-        expect(reduxTaxi.getRegisteredActions().size).toEqual(1);
-        expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
+    reduxTaxi.register(actionType1);
+    expect(reduxTaxi.getRegisteredActions().size).toEqual(1);
+    expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
 
-        reduxTaxi.register(actionType2);
-        expect(reduxTaxi.getRegisteredActions().size).toEqual(2);
-        expect(reduxTaxi.isRegistered(actionType2)).toBeTruthy();
-    });
+    reduxTaxi.register(actionType2);
+    expect(reduxTaxi.getRegisteredActions().size).toEqual(2);
+    expect(reduxTaxi.isRegistered(actionType2)).toBeTruthy();
+  });
 
-    it('should only register the same action type once', () => {
-        expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
+  it('should only register the same action type once', () => {
+    expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
 
-        reduxTaxi.register(actionType1);
-        reduxTaxi.register(actionType1);
+    reduxTaxi.register(actionType1);
+    reduxTaxi.register(actionType1);
 
-        expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
-        expect(reduxTaxi.getRegisteredActions().size).toEqual(1);
-    });
+    expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
+    expect(reduxTaxi.getRegisteredActions().size).toEqual(1);
+  });
 
-    it('should return false for an unregistered action', () => {
-        expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
-    });
+  it('should return false for an unregistered action', () => {
+    expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
+  });
 
-    it('should return true for a registered action', () => {
-        reduxTaxi.register(actionType1);
-        expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
-    });
+  it('should return true for a registered action', () => {
+    reduxTaxi.register(actionType1);
+    expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
+  });
 
-    it('should be able to collect promises', () => {
-        const promise = new Promise(() => {}, () => {});
+  it('should be able to collect promises', () => {
+    const promise = new Promise(() => {}, () => {});
 
-        expect(reduxTaxi.getAllPromises()).toBeInstanceOf(Array);
-        expect(reduxTaxi.getAllPromises()).toHaveLength(0);
+    expect(reduxTaxi.getAllPromises()).toBeInstanceOf(Array);
+    expect(reduxTaxi.getAllPromises()).toHaveLength(0);
 
-        reduxTaxi.collectPromise(promise);
-        expect(reduxTaxi.getAllPromises()).toHaveLength(1);
+    reduxTaxi.collectPromise(promise);
+    expect(reduxTaxi.getAllPromises()).toHaveLength(1);
 
-        reduxTaxi.collectPromise(promise);
-        expect(reduxTaxi.getAllPromises()).toHaveLength(2);
+    reduxTaxi.collectPromise(promise);
+    expect(reduxTaxi.getAllPromises()).toHaveLength(2);
 
-        reduxTaxi.collectPromise(promise);
-        expect(reduxTaxi.getAllPromises()).toHaveLength(3);
-    });
+    reduxTaxi.collectPromise(promise);
+    expect(reduxTaxi.getAllPromises()).toHaveLength(3);
+  });
 });

--- a/tests/ReduxTaxi.test.js
+++ b/tests/ReduxTaxi.test.js
@@ -1,10 +1,8 @@
-import {assert} from 'chai';
-import {ReduxTaxi} from '../src/index';
+import { ReduxTaxi } from '../src/index';
 
 describe('ReduxTaxi', () => {
     const actionType1 = 'test1';
     const actionType2 = 'test2';
-    const promise = new Promise(() => {}, () => {});
     let reduxTaxi;
 
     beforeEach(() => {
@@ -12,49 +10,51 @@ describe('ReduxTaxi', () => {
     });
 
     it('should correctly register an action', () => {
-        assert.strictEqual(reduxTaxi.getRegisteredActions().size, 0);
-        assert.isFalse(reduxTaxi.isRegistered(actionType1));
-        assert.isFalse(reduxTaxi.isRegistered(actionType2));
+        expect(reduxTaxi.getRegisteredActions().size).toEqual(0);
+        expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
+        expect(reduxTaxi.isRegistered(actionType2)).toBeFalsy();
 
         reduxTaxi.register(actionType1);
-        assert.strictEqual(reduxTaxi.getRegisteredActions().size, 1);
-        assert.isTrue(reduxTaxi.isRegistered(actionType1));
+        expect(reduxTaxi.getRegisteredActions().size).toEqual(1);
+        expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
 
         reduxTaxi.register(actionType2);
-        assert.strictEqual(reduxTaxi.getRegisteredActions().size, 2);
-        assert.isTrue(reduxTaxi.isRegistered(actionType2));
+        expect(reduxTaxi.getRegisteredActions().size).toEqual(2);
+        expect(reduxTaxi.isRegistered(actionType2)).toBeTruthy();
     });
 
     it('should only register the same action type once', () => {
-        assert.isFalse(reduxTaxi.isRegistered(actionType1));
+        expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
 
         reduxTaxi.register(actionType1);
         reduxTaxi.register(actionType1);
 
-        assert.strictEqual(reduxTaxi.getRegisteredActions().size, 1);
-        assert.isTrue(reduxTaxi.isRegistered(actionType1));
+        expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
+        expect(reduxTaxi.getRegisteredActions().size).toEqual(1);
     });
 
     it('should return false for an unregistered action', () => {
-        assert.isFalse(reduxTaxi.isRegistered(actionType1));
+        expect(reduxTaxi.isRegistered(actionType1)).toBeFalsy();
     });
 
     it('should return true for a registered action', () => {
         reduxTaxi.register(actionType1);
-        assert.isTrue(reduxTaxi.isRegistered(actionType1));
+        expect(reduxTaxi.isRegistered(actionType1)).toBeTruthy();
     });
 
     it('should be able to collect promises', () => {
-        assert.isArray(reduxTaxi.getAllPromises());
-        assert.strictEqual(reduxTaxi.getAllPromises().length, 0);
+        const promise = new Promise(() => {}, () => {});
+
+        expect(reduxTaxi.getAllPromises()).toBeInstanceOf(Array);
+        expect(reduxTaxi.getAllPromises()).toHaveLength(0);
 
         reduxTaxi.collectPromise(promise);
-        assert.strictEqual(reduxTaxi.getAllPromises().length, 1);
+        expect(reduxTaxi.getAllPromises()).toHaveLength(1);
 
         reduxTaxi.collectPromise(promise);
-        assert.strictEqual(reduxTaxi.getAllPromises().length, 2);
+        expect(reduxTaxi.getAllPromises()).toHaveLength(2);
 
         reduxTaxi.collectPromise(promise);
-        assert.strictEqual(reduxTaxi.getAllPromises().length, 3);
+        expect(reduxTaxi.getAllPromises()).toHaveLength(3);
     });
 });

--- a/tests/ReduxTaxiMiddleware.test.js
+++ b/tests/ReduxTaxiMiddleware.test.js
@@ -3,7 +3,7 @@ import { ReduxTaxiMiddleware } from '../src/index';
 describe('ReduxTaxiMiddleware', () => {
     const mockReduxTaxi = {
         isRegistered() {},
-        collectPromise() {},
+        collectPromise() {}
     };
     const nextHandler = ReduxTaxiMiddleware(mockReduxTaxi)();
 
@@ -12,11 +12,11 @@ describe('ReduxTaxiMiddleware', () => {
     const testPromise = new Promise(() => {}, () => {});
     const syncAction = {
         type: SYNC_TYPE,
-        payload: {},
+        payload: {}
     };
     const asyncAction = {
         type: ASYNC_TYPE,
-        promise: testPromise,
+        promise: testPromise
     };
 
     it('must return a function to handle next', () => {

--- a/tests/ReduxTaxiMiddleware.test.js
+++ b/tests/ReduxTaxiMiddleware.test.js
@@ -3,7 +3,7 @@ import { ReduxTaxiMiddleware } from '../src/index';
 describe('ReduxTaxiMiddleware', () => {
     const mockReduxTaxi = {
         isRegistered() {},
-        collectPromise() {}
+        collectPromise() {},
     };
     const nextHandler = ReduxTaxiMiddleware(mockReduxTaxi)();
 
@@ -12,11 +12,11 @@ describe('ReduxTaxiMiddleware', () => {
     const testPromise = new Promise(() => {}, () => {});
     const syncAction = {
         type: SYNC_TYPE,
-        payload: {}
+        payload: {},
     };
     const asyncAction = {
         type: ASYNC_TYPE,
-        promise: testPromise
+        promise: testPromise,
     };
 
     it('must return a function to handle next', () => {

--- a/tests/ReduxTaxiMiddleware.test.js
+++ b/tests/ReduxTaxiMiddleware.test.js
@@ -1,11 +1,9 @@
-import {assert} from 'chai';
-import sinon from 'sinon';
-import {ReduxTaxiMiddleware} from '../src/index';
+import { ReduxTaxiMiddleware } from '../src/index';
 
 describe('ReduxTaxiMiddleware', () => {
     const mockReduxTaxi = {
         isRegistered() {},
-        collectPromise() {}
+        collectPromise() {},
     };
     const nextHandler = ReduxTaxiMiddleware(mockReduxTaxi)();
 
@@ -14,62 +12,65 @@ describe('ReduxTaxiMiddleware', () => {
     const testPromise = new Promise(() => {}, () => {});
     const syncAction = {
         type: SYNC_TYPE,
-        payload: {}
+        payload: {},
     };
     const asyncAction = {
         type: ASYNC_TYPE,
-        promise: testPromise
+        promise: testPromise,
     };
 
     it('must return a function to handle next', () => {
-        assert.isFunction(nextHandler);
-        assert.strictEqual(nextHandler.length, 1);
+        expect(nextHandler).toBeInstanceOf(Function);
+        expect(nextHandler).toHaveLength(1);
     });
 
     describe('handle next', () => {
         it('must return a function to handle action', () => {
             const actionHandler = nextHandler();
 
-            assert.isFunction(actionHandler);
-            assert.strictEqual(actionHandler.length, 1);
+            expect(actionHandler).toBeInstanceOf(Function);
+            expect(actionHandler).toHaveLength(1);
         });
 
         describe('handle action', () => {
-            it('must pass actions without promises to the next handler', done => {
-                const actionHandler = nextHandler(action => {
-                    assert.strictEqual(action, syncAction);
-                    done();
-                });
+            it('must pass actions without promises to the next handler', () => {
+                const actionSpy = jest.fn();
+                const actionHandler = nextHandler(actionSpy);
 
                 actionHandler(syncAction);
+                expect(actionSpy).toHaveBeenCalledTimes(1);
+                expect(actionSpy).toHaveBeenCalledWith(syncAction);
             });
 
-            it('must throw an error if the action is not registered', done => {
-                sinon.stub(mockReduxTaxi, 'isRegistered', () => false);
+            it('must throw an error if the action is not registered', () => {
+                mockReduxTaxi.isRegistered = jest.fn(() => false);
+
                 try {
                     nextHandler()(asyncAction);
                 } catch (err) {
-                    assert.isTrue(err.message.indexOf(ASYNC_TYPE) > -1);
-                    done();
+                    expect(err.message).toEqual(
+                        expect.stringMatching(/ASYNC_TYPE/)
+                    );
                 }
-                mockReduxTaxi.isRegistered.restore();
+
+                expect(mockReduxTaxi.isRegistered).toHaveBeenCalledTimes(1);
             });
 
-            it('must collect promises for registered actions', done => {
-                sinon.stub(mockReduxTaxi, 'isRegistered', () => true);
-                sinon.stub(mockReduxTaxi, 'collectPromise', (promise) => {
-                    assert.strictEqual(testPromise, promise);
-                    done();
-                });
+            it('must collect promises for registered actions', () => {
+                const promiseSpy = jest.fn();
+                const actionSpy = jest.fn();
+                mockReduxTaxi.isRegistered = jest.fn(() => true);
+                mockReduxTaxi.collectPromise = promiseSpy;
 
-                const actionHandler = nextHandler(action => {
-                    assert.strictEqual(action, asyncAction);
-                });
+                const actionHandler = nextHandler(actionSpy);
 
                 actionHandler(asyncAction);
 
-                mockReduxTaxi.isRegistered.restore();
-                mockReduxTaxi.collectPromise.restore();
+                expect(promiseSpy).toHaveBeenCalledTimes(1);
+                expect(promiseSpy).toHaveBeenCalledWith(testPromise);
+
+                expect(actionSpy).toHaveBeenCalledTimes(1);
+                expect(actionSpy).toHaveBeenCalledWith(asyncAction);
             });
         }); // end describe('handle action')
     }); // end describe('handle next')

--- a/tests/ReduxTaxiMiddleware.test.js
+++ b/tests/ReduxTaxiMiddleware.test.js
@@ -1,77 +1,75 @@
 import { ReduxTaxiMiddleware } from '../src/index';
 
 describe('ReduxTaxiMiddleware', () => {
-    const mockReduxTaxi = {
-        isRegistered() {},
-        collectPromise() {},
-    };
-    const nextHandler = ReduxTaxiMiddleware(mockReduxTaxi)();
+  const mockReduxTaxi = {
+    isRegistered() {},
+    collectPromise() {},
+  };
+  const nextHandler = ReduxTaxiMiddleware(mockReduxTaxi)();
 
-    const SYNC_TYPE = 'SYNC_TYPE';
-    const ASYNC_TYPE = 'ASYNC_TYPE';
-    const testPromise = new Promise(() => {}, () => {});
-    const syncAction = {
-        type: SYNC_TYPE,
-        payload: {},
-    };
-    const asyncAction = {
-        type: ASYNC_TYPE,
-        promise: testPromise,
-    };
+  const SYNC_TYPE = 'SYNC_TYPE';
+  const ASYNC_TYPE = 'ASYNC_TYPE';
+  const testPromise = new Promise(() => {}, () => {});
+  const syncAction = {
+    type: SYNC_TYPE,
+    payload: {},
+  };
+  const asyncAction = {
+    type: ASYNC_TYPE,
+    promise: testPromise,
+  };
 
-    it('must return a function to handle next', () => {
-        expect(nextHandler).toBeInstanceOf(Function);
-        expect(nextHandler).toHaveLength(1);
+  it('must return a function to handle next', () => {
+    expect(nextHandler).toBeInstanceOf(Function);
+    expect(nextHandler).toHaveLength(1);
+  });
+
+  describe('handle next', () => {
+    it('must return a function to handle action', () => {
+      const actionHandler = nextHandler();
+
+      expect(actionHandler).toBeInstanceOf(Function);
+      expect(actionHandler).toHaveLength(1);
     });
 
-    describe('handle next', () => {
-        it('must return a function to handle action', () => {
-            const actionHandler = nextHandler();
+    describe('handle action', () => {
+      it('must pass actions without promises to the next handler', () => {
+        const actionSpy = jest.fn();
+        const actionHandler = nextHandler(actionSpy);
 
-            expect(actionHandler).toBeInstanceOf(Function);
-            expect(actionHandler).toHaveLength(1);
-        });
+        actionHandler(syncAction);
+        expect(actionSpy).toHaveBeenCalledTimes(1);
+        expect(actionSpy).toHaveBeenCalledWith(syncAction);
+      });
 
-        describe('handle action', () => {
-            it('must pass actions without promises to the next handler', () => {
-                const actionSpy = jest.fn();
-                const actionHandler = nextHandler(actionSpy);
+      it('must throw an error if the action is not registered', () => {
+        mockReduxTaxi.isRegistered = jest.fn(() => false);
 
-                actionHandler(syncAction);
-                expect(actionSpy).toHaveBeenCalledTimes(1);
-                expect(actionSpy).toHaveBeenCalledWith(syncAction);
-            });
+        try {
+          nextHandler()(asyncAction);
+        } catch (err) {
+          expect(err.message).toEqual(expect.stringMatching(/ASYNC_TYPE/));
+        }
 
-            it('must throw an error if the action is not registered', () => {
-                mockReduxTaxi.isRegistered = jest.fn(() => false);
+        expect(mockReduxTaxi.isRegistered).toHaveBeenCalledTimes(1);
+      });
 
-                try {
-                    nextHandler()(asyncAction);
-                } catch (err) {
-                    expect(err.message).toEqual(
-                        expect.stringMatching(/ASYNC_TYPE/)
-                    );
-                }
+      it('must collect promises for registered actions', () => {
+        const promiseSpy = jest.fn();
+        const actionSpy = jest.fn();
+        mockReduxTaxi.isRegistered = jest.fn(() => true);
+        mockReduxTaxi.collectPromise = promiseSpy;
 
-                expect(mockReduxTaxi.isRegistered).toHaveBeenCalledTimes(1);
-            });
+        const actionHandler = nextHandler(actionSpy);
 
-            it('must collect promises for registered actions', () => {
-                const promiseSpy = jest.fn();
-                const actionSpy = jest.fn();
-                mockReduxTaxi.isRegistered = jest.fn(() => true);
-                mockReduxTaxi.collectPromise = promiseSpy;
+        actionHandler(asyncAction);
 
-                const actionHandler = nextHandler(actionSpy);
+        expect(promiseSpy).toHaveBeenCalledTimes(1);
+        expect(promiseSpy).toHaveBeenCalledWith(testPromise);
 
-                actionHandler(asyncAction);
-
-                expect(promiseSpy).toHaveBeenCalledTimes(1);
-                expect(promiseSpy).toHaveBeenCalledWith(testPromise);
-
-                expect(actionSpy).toHaveBeenCalledTimes(1);
-                expect(actionSpy).toHaveBeenCalledWith(asyncAction);
-            });
-        }); // end describe('handle action')
-    }); // end describe('handle next')
+        expect(actionSpy).toHaveBeenCalledTimes(1);
+        expect(actionSpy).toHaveBeenCalledWith(asyncAction);
+      });
+    }); // end describe('handle action')
+  }); // end describe('handle next')
 });

--- a/tests/ReduxTaxiProvider.test.js
+++ b/tests/ReduxTaxiProvider.test.js
@@ -1,13 +1,12 @@
-import {assert} from 'chai';
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import TestUtils from 'react-dom/test-utils';
-import {ReduxTaxiProvider} from '../src/index';
+import { ReduxTaxiProvider } from '../src/index';
 
 describe('ReduxTaxiProvider', () => {
     class Child extends Component {
         static contextTypes = {
-            reduxTaxi: PropTypes.object.isRequired
+            reduxTaxi: PropTypes.object.isRequired,
         };
 
         render() {
@@ -19,23 +18,48 @@ describe('ReduxTaxiProvider', () => {
     const propTypes = ReduxTaxiProvider.propTypes;
     ReduxTaxiProvider.propTypes = {};
 
-    it.skip('should enforce a single child', () => {
+    it('should not throw an error with a single child', () => {
         try {
-            assert.doesNotThrow(() => TestUtils.renderIntoDocument(
+            TestUtils.renderIntoDocument(
                 <ReduxTaxiProvider reduxTaxi={{}}>
                     <div />
                 </ReduxTaxiProvider>
-            ));
-            assert.throws(() => TestUtils.renderIntoDocument(
-                <ReduxTaxiProvider reduxTaxi={{}} />
-            ), /exactly one child/);
-
-            assert.throws(() => TestUtils.renderIntoDocument(
+            );
+        } catch (err) {
+            fail('Render throw an error.');
+        } finally {
+            ReduxTaxiProvider.propTypes = propTypes;
+        }
+    });
+    it('should thow an error if no child is present.', () => {
+        try {
+            TestUtils.renderIntoDocument(
+                <ReduxTaxiProvider reduxTaxi={{}} children="" />
+            );
+        } catch (err) {
+            expect(err.message).toEqual(
+                expect.stringMatching(
+                    /only expected to receive a single React element child/
+                )
+            );
+        } finally {
+            ReduxTaxiProvider.propTypes = propTypes;
+        }
+    });
+    it('should enforce a single child', () => {
+        try {
+            TestUtils.renderIntoDocument(
                 <ReduxTaxiProvider reduxTaxi={{}}>
                     <div />
                     <div />
                 </ReduxTaxiProvider>
-            ), /exactly one child/);
+            );
+        } catch (err) {
+            expect(err.message).toEqual(
+                expect.stringMatching(
+                    /expected to receive a single React element child/
+                )
+            );
         } finally {
             ReduxTaxiProvider.propTypes = propTypes;
         }
@@ -51,6 +75,6 @@ describe('ReduxTaxiProvider', () => {
         );
 
         const child = TestUtils.findRenderedComponentWithType(tree, Child);
-        assert.strictEqual(child.context.reduxTaxi, reduxTaxi);
+        expect(child.context.reduxTaxi).toEqual(reduxTaxi);
     });
 });

--- a/tests/ReduxTaxiProvider.test.js
+++ b/tests/ReduxTaxiProvider.test.js
@@ -4,77 +4,77 @@ import TestUtils from 'react-dom/test-utils';
 import { ReduxTaxiProvider } from '../src/index';
 
 describe('ReduxTaxiProvider', () => {
-    class Child extends Component {
-        static contextTypes = {
-            reduxTaxi: PropTypes.object.isRequired,
-        };
+  class Child extends Component {
+    static contextTypes = {
+      reduxTaxi: PropTypes.object.isRequired,
+    };
 
-        render() {
-            return <div />;
-        }
+    render() {
+      return <div />;
     }
+  }
 
-    // Ignore propTypes warnings
-    const propTypes = ReduxTaxiProvider.propTypes;
-    ReduxTaxiProvider.propTypes = {};
+  // Ignore propTypes warnings
+  const propTypes = ReduxTaxiProvider.propTypes;
+  ReduxTaxiProvider.propTypes = {};
 
-    it('should not throw an error with a single child', () => {
-        try {
-            TestUtils.renderIntoDocument(
-                <ReduxTaxiProvider reduxTaxi={{}}>
-                    <div />
-                </ReduxTaxiProvider>
-            );
-        } catch (err) {
-            fail('Render throw an error.');
-        } finally {
-            ReduxTaxiProvider.propTypes = propTypes;
-        }
-    });
-    it('should thow an error if no child is present.', () => {
-        try {
-            TestUtils.renderIntoDocument(
-                <ReduxTaxiProvider reduxTaxi={{}} children="" />
-            );
-        } catch (err) {
-            expect(err.message).toEqual(
-                expect.stringMatching(
-                    /only expected to receive a single React element child/
-                )
-            );
-        } finally {
-            ReduxTaxiProvider.propTypes = propTypes;
-        }
-    });
-    it('should enforce a single child', () => {
-        try {
-            TestUtils.renderIntoDocument(
-                <ReduxTaxiProvider reduxTaxi={{}}>
-                    <div />
-                    <div />
-                </ReduxTaxiProvider>
-            );
-        } catch (err) {
-            expect(err.message).toEqual(
-                expect.stringMatching(
-                    /expected to receive a single React element child/
-                )
-            );
-        } finally {
-            ReduxTaxiProvider.propTypes = propTypes;
-        }
-    });
+  it('should not throw an error with a single child', () => {
+    try {
+      TestUtils.renderIntoDocument(
+        <ReduxTaxiProvider reduxTaxi={{}}>
+          <div />
+        </ReduxTaxiProvider>
+      );
+    } catch (err) {
+      fail('Render throw an error.');
+    } finally {
+      ReduxTaxiProvider.propTypes = propTypes;
+    }
+  });
+  it('should thow an error if no child is present.', () => {
+    try {
+      TestUtils.renderIntoDocument(
+        <ReduxTaxiProvider reduxTaxi={{}} children="" />
+      );
+    } catch (err) {
+      expect(err.message).toEqual(
+        expect.stringMatching(
+          /only expected to receive a single React element child/
+        )
+      );
+    } finally {
+      ReduxTaxiProvider.propTypes = propTypes;
+    }
+  });
+  it('should enforce a single child', () => {
+    try {
+      TestUtils.renderIntoDocument(
+        <ReduxTaxiProvider reduxTaxi={{}}>
+          <div />
+          <div />
+        </ReduxTaxiProvider>
+      );
+    } catch (err) {
+      expect(err.message).toEqual(
+        expect.stringMatching(
+          /expected to receive a single React element child/
+        )
+      );
+    } finally {
+      ReduxTaxiProvider.propTypes = propTypes;
+    }
+  });
 
-    it('should add the reduxTaxi to the child context', () => {
-        const reduxTaxi = {};
+  it('should add the reduxTaxi to the child context', () => {
+    const reduxTaxi = {};
 
-        const tree = TestUtils.renderIntoDocument(
-            <ReduxTaxiProvider reduxTaxi={reduxTaxi}>
-                <Child />
-            </ReduxTaxiProvider>
-        );
+    const tree = TestUtils.renderIntoDocument(
+      <ReduxTaxiProvider reduxTaxi={reduxTaxi}>
+        <Child />
+      </ReduxTaxiProvider>
+    );
 
-        const child = TestUtils.findRenderedComponentWithType(tree, Child);
-        expect(child.context.reduxTaxi).toEqual(reduxTaxi);
-    });
+    const child = TestUtils.findRenderedComponentWithType(tree, Child);
+    expect(child.context.reduxTaxi).toEqual(reduxTaxi);
+  });
 });

--- a/tests/registerAsyncActions.test.js
+++ b/tests/registerAsyncActions.test.js
@@ -4,82 +4,82 @@ import TestUtils from 'react-dom/test-utils';
 import { registerAsyncActions } from '../src/index';
 
 describe('registerAsyncActions', () => {
-    const TEST_ACTION1 = 'TEST_ACTION1';
-    const TEST_ACTION2 = 'TEST_ACTION2';
-    const TEST_ACTION3 = 'TEST_ACTION3';
+  const TEST_ACTION1 = 'TEST_ACTION1';
+  const TEST_ACTION2 = 'TEST_ACTION2';
+  const TEST_ACTION3 = 'TEST_ACTION3';
 
-    const mockReduxTaxi = {
-        register() {},
+  const mockReduxTaxi = {
+    register() {},
+  };
+
+  class StaticComponent extends Component {
+    render() {
+      return <div />;
+    }
+  }
+
+  class MockReduxTaxiProvider extends Component {
+    static propTypes = {
+      children: PropTypes.node.isRequired,
     };
 
-    class StaticComponent extends Component {
-        render() {
-            return <div />;
-        }
+    static childContextTypes = {
+      reduxTaxi: PropTypes.object,
+    };
+
+    getChildContext() {
+      return {
+        reduxTaxi: mockReduxTaxi,
+      };
     }
 
-    class MockReduxTaxiProvider extends Component {
-        static propTypes = {
-            children: PropTypes.node.isRequired,
-        };
-
-        static childContextTypes = {
-            reduxTaxi: PropTypes.object,
-        };
-
-        getChildContext() {
-            return {
-                reduxTaxi: mockReduxTaxi,
-            };
-        }
-
-        render() {
-            return React.Children.only(this.props.children);
-        }
+    render() {
+      return React.Children.only(this.props.children);
     }
+  }
 
-    beforeEach(() => {
-        mockReduxTaxi.register = jest.fn();
-    });
+  beforeEach(() => {
+    mockReduxTaxi.register = jest.fn();
+  });
 
-    it('should register a single action passed in', () => {
-        @registerAsyncActions(TEST_ACTION1)
-        class TestComponent extends StaticComponent {}
+  it('should register a single action passed in', () => {
+    @registerAsyncActions(TEST_ACTION1)
+    class TestComponent extends StaticComponent {}
 
-        TestUtils.renderIntoDocument(
-            <MockReduxTaxiProvider>
-                <TestComponent />
-            </MockReduxTaxiProvider>
-        );
+    TestUtils.renderIntoDocument(
+      <MockReduxTaxiProvider>
+        <TestComponent />
+      </MockReduxTaxiProvider>
+    );
 
-        expect(mockReduxTaxi.register).toHaveBeenCalledTimes(1);
-        expect(mockReduxTaxi.register).toHaveBeenCalledWith(TEST_ACTION1);
-    });
+    expect(mockReduxTaxi.register).toHaveBeenCalledTimes(1);
+    expect(mockReduxTaxi.register).toHaveBeenCalledWith(TEST_ACTION1);
+  });
 
-    it('should register a list of actions passed in', () => {
-        @registerAsyncActions(TEST_ACTION1, TEST_ACTION2, TEST_ACTION3)
-        class TestComponent extends StaticComponent {}
+  it('should register a list of actions passed in', () => {
+    @registerAsyncActions(TEST_ACTION1, TEST_ACTION2, TEST_ACTION3)
+    class TestComponent extends StaticComponent {}
 
-        TestUtils.renderIntoDocument(
-            <MockReduxTaxiProvider>
-                <TestComponent />
-            </MockReduxTaxiProvider>
-        );
+    TestUtils.renderIntoDocument(
+      <MockReduxTaxiProvider>
+        <TestComponent />
+      </MockReduxTaxiProvider>
+    );
 
-        const { register } = mockReduxTaxi;
+    const { register } = mockReduxTaxi;
 
-        expect(register).toHaveBeenCalledTimes(3);
-        expect(register.mock.calls[0][0]).toEqual(TEST_ACTION1);
-        expect(register.mock.calls[1][0]).toEqual(TEST_ACTION2);
-        expect(register.mock.calls[2][0]).toEqual(TEST_ACTION3);
-    });
+    expect(register).toHaveBeenCalledTimes(3);
+    expect(register.mock.calls[0][0]).toEqual(TEST_ACTION1);
+    expect(register.mock.calls[1][0]).toEqual(TEST_ACTION2);
+    expect(register.mock.calls[2][0]).toEqual(TEST_ACTION3);
+  });
 
-    it('should not register actions when reduxTaxi context is not available', () => {
-        @registerAsyncActions(TEST_ACTION1, TEST_ACTION2, TEST_ACTION3)
-        class TestComponent extends StaticComponent {}
+  it('should not register actions when reduxTaxi context is not available', () => {
+    @registerAsyncActions(TEST_ACTION1, TEST_ACTION2, TEST_ACTION3)
+    class TestComponent extends StaticComponent {}
 
-        TestUtils.renderIntoDocument(<TestComponent />);
+    TestUtils.renderIntoDocument(<TestComponent />);
 
-        expect(mockReduxTaxi.register).toHaveBeenCalledTimes(0);
-    });
+    expect(mockReduxTaxi.register).toHaveBeenCalledTimes(0);
+  });
 });

--- a/tests/registerAsyncActions.test.js
+++ b/tests/registerAsyncActions.test.js
@@ -1,9 +1,7 @@
-import {assert} from 'chai';
-import sinon from 'sinon';
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import TestUtils from 'react-dom/test-utils';
-import {registerAsyncActions} from '../src/index';
+import { registerAsyncActions } from '../src/index';
 
 describe('registerAsyncActions', () => {
     const TEST_ACTION1 = 'TEST_ACTION1';
@@ -11,7 +9,7 @@ describe('registerAsyncActions', () => {
     const TEST_ACTION3 = 'TEST_ACTION3';
 
     const mockReduxTaxi = {
-        register() {}
+        register() {},
     };
 
     class StaticComponent extends Component {
@@ -22,16 +20,16 @@ describe('registerAsyncActions', () => {
 
     class MockReduxTaxiProvider extends Component {
         static propTypes = {
-            children: PropTypes.node.isRequired
+            children: PropTypes.node.isRequired,
         };
 
         static childContextTypes = {
-            reduxTaxi: PropTypes.object
+            reduxTaxi: PropTypes.object,
         };
 
         getChildContext() {
             return {
-                reduxTaxi: mockReduxTaxi
+                reduxTaxi: mockReduxTaxi,
             };
         }
 
@@ -41,11 +39,7 @@ describe('registerAsyncActions', () => {
     }
 
     beforeEach(() => {
-        sinon.spy(mockReduxTaxi, 'register');
-    });
-
-    afterEach(() => {
-        mockReduxTaxi.register.restore();
+        mockReduxTaxi.register = jest.fn();
     });
 
     it('should register a single action passed in', () => {
@@ -58,8 +52,8 @@ describe('registerAsyncActions', () => {
             </MockReduxTaxiProvider>
         );
 
-        assert.isTrue(mockReduxTaxi.register.calledOnce);
-        assert(mockReduxTaxi.register.calledWith(TEST_ACTION1));
+        expect(mockReduxTaxi.register).toHaveBeenCalledTimes(1);
+        expect(mockReduxTaxi.register).toHaveBeenCalledWith(TEST_ACTION1);
     });
 
     it('should register a list of actions passed in', () => {
@@ -72,11 +66,12 @@ describe('registerAsyncActions', () => {
             </MockReduxTaxiProvider>
         );
 
-        assert.isTrue(mockReduxTaxi.register.calledThrice);
+        const { register } = mockReduxTaxi;
 
-        assert.strictEqual(mockReduxTaxi.register.getCall(0).args[0], TEST_ACTION1);
-        assert.strictEqual(mockReduxTaxi.register.getCall(1).args[0], TEST_ACTION2);
-        assert.strictEqual(mockReduxTaxi.register.getCall(2).args[0], TEST_ACTION3);
+        expect(register).toHaveBeenCalledTimes(3);
+        expect(register.mock.calls[0][0]).toEqual(TEST_ACTION1);
+        expect(register.mock.calls[1][0]).toEqual(TEST_ACTION2);
+        expect(register.mock.calls[2][0]).toEqual(TEST_ACTION3);
     });
 
     it('should not register actions when reduxTaxi context is not available', () => {
@@ -85,6 +80,6 @@ describe('registerAsyncActions', () => {
 
         TestUtils.renderIntoDocument(<TestComponent />);
 
-        assert.strictEqual(mockReduxTaxi.register.callCount, 0);
+        expect(mockReduxTaxi.register).toHaveBeenCalledTimes(0);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,10 +56,6 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -88,10 +84,6 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
-
-app-root-path@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -1140,7 +1132,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1150,7 +1142,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1, chalk@^2.1.0:
+chalk@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
@@ -1176,23 +1168,6 @@ chokidar@^1.6.1:
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
-
-cli-cursor@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  dependencies:
-    restore-cursor "^1.0.1"
-
-cli-spinners@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
-
-cli-truncate@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
-  dependencies:
-    slice-ansi "0.0.4"
-    string-width "^1.0.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1240,10 +1215,6 @@ commander@^2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1275,19 +1246,6 @@ core-js@^2.5.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cosmiconfig@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
-  dependencies:
-    graceful-fs "^4.1.2"
-    js-yaml "^3.4.3"
-    minimist "^1.2.0"
-    object-assign "^4.0.1"
-    os-homedir "^1.0.1"
-    parse-json "^2.2.0"
-    pinkie-promise "^2.0.0"
-    require-from-string "^1.1.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1324,10 +1282,6 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
-
-date-fns@^1.27.2:
-  version "1.28.5"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.3"
@@ -1382,10 +1336,6 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
-
-elegant-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -1458,22 +1408,6 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -1540,13 +1474,6 @@ fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
-
-figures@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1667,10 +1594,6 @@ gauge@~2.7.1:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-
-get-own-enumerable-property-symbols@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1846,14 +1769,6 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-husky@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
-
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -1865,16 +1780,6 @@ iconv-lite@~0.4.13:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-
-indent-string@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  dependencies:
-    repeating "^2.0.0"
-
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1945,10 +1850,6 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-extglob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1971,21 +1872,11 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-glob@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
-  dependencies:
-    is-extglob "^2.1.1"
-
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
   dependencies:
     kind-of "^3.0.2"
-
-is-obj@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -1994,14 +1885,6 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-
-is-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2313,7 +2196,7 @@ jest-util@^21.2.1:
     jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
-jest-validate@^21.1.0, jest-validate@^21.2.1:
+jest-validate@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
   dependencies:
@@ -2342,7 +2225,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0:
+js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2446,72 +2329,6 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lint-staged@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.3.tgz#5a1f12256af06110b96225f109dbf215009a37a9"
-  dependencies:
-    app-root-path "^2.0.0"
-    chalk "^2.1.0"
-    cosmiconfig "^1.1.0"
-    execa "^0.8.0"
-    is-glob "^4.0.0"
-    jest-validate "^21.1.0"
-    listr "^0.12.0"
-    lodash "^4.17.4"
-    log-symbols "^2.0.0"
-    minimatch "^3.0.0"
-    npm-which "^3.0.1"
-    p-map "^1.1.1"
-    staged-git-files "0.0.4"
-    stringify-object "^3.2.0"
-
-listr-silent-renderer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
-
-listr-update-renderer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-listr-verbose-renderer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
-listr@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    figures "^1.7.0"
-    indent-string "^2.1.0"
-    is-promise "^2.1.0"
-    is-stream "^1.1.0"
-    listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.2.0"
-    listr-verbose-renderer "^0.4.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    ora "^0.2.3"
-    p-map "^1.1.1"
-    rxjs "^5.0.0-beta.11"
-    stream-to-observable "^0.1.0"
-    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -2733,35 +2550,17 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-npm-path@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
-  dependencies:
-    which "^1.2.10"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
-
-npm-which@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
-  dependencies:
-    commander "^2.9.0"
-    npm-path "^2.0.2"
-    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.0.2"
@@ -2784,7 +2583,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2800,10 +2599,6 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
-
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2823,16 +2618,7 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
-  dependencies:
-    chalk "^1.1.1"
-    cli-cursor "^1.0.2"
-    cli-spinners "^0.1.2"
-    object-assign "^4.0.1"
-
-os-homedir@^1.0.0, os-homedir@^1.0.1:
+os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -2880,10 +2666,6 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
-
-p-map@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -2973,10 +2755,6 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-
-prettier@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 pretty-format@^21.2.1:
   version "21.2.1"
@@ -3231,10 +3009,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
-require-from-string@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
-
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3242,13 +3016,6 @@ require-main-filename@^1.0.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3261,12 +3028,6 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
-
-rxjs@^5.0.0-beta.11:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
-  dependencies:
-    symbol-observable "^1.0.1"
 
 safe-buffer@^5.0.1:
   version "5.0.1"
@@ -3343,10 +3104,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3425,14 +3182,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-staged-git-files@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
-
-stream-to-observable@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
-
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -3460,14 +3209,6 @@ string_decoder@~1.0.0:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
   dependencies:
     buffer-shims "~1.0.0"
-
-stringify-object@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.1.tgz#2720c2eff940854c819f6ee252aaeb581f30624d"
-  dependencies:
-    get-own-enumerable-property-symbols "^2.0.1"
-    is-obj "^1.0.1"
-    is-regexp "^1.0.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -3499,10 +3240,6 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -3522,10 +3259,6 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
-
-symbol-observable@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -3724,7 +3457,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.10, which@^1.2.12, which@^1.2.9:
+which@^1.2.12, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,6 +3329,12 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tough-cookie@~2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  dependencies:
+    punycode "^1.4.1"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,6 +2974,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-escapes@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -84,6 +88,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -1132,7 +1140,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.0, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1142,7 +1150,7 @@ chalk@^1.1.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1:
+chalk@^2.0.1, chalk@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
@@ -1168,6 +1176,23 @@ chokidar@^1.6.1:
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+
+cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1215,6 +1240,10 @@ commander@^2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1246,6 +1275,19 @@ core-js@^2.5.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1282,6 +1324,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.3"
@@ -1336,6 +1382,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -1408,6 +1458,22 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -1474,6 +1540,13 @@ fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1594,6 +1667,10 @@ gauge@~2.7.1:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1769,6 +1846,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -1780,6 +1865,16 @@ iconv-lite@~0.4.13:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1850,6 +1945,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1872,11 +1971,21 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -1885,6 +1994,14 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2196,7 +2313,7 @@ jest-util@^21.2.1:
     jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
-jest-validate@^21.2.1:
+jest-validate@^21.1.0, jest-validate@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
   dependencies:
@@ -2225,7 +2342,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2329,6 +2446,72 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lint-staged@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.3.tgz#5a1f12256af06110b96225f109dbf215009a37a9"
+  dependencies:
+    app-root-path "^2.0.0"
+    chalk "^2.1.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.8.0"
+    is-glob "^4.0.0"
+    jest-validate "^21.1.0"
+    listr "^0.12.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    staged-git-files "0.0.4"
+    stringify-object "^3.2.0"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -2550,17 +2733,35 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.0.2"
@@ -2583,7 +2784,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2599,6 +2800,10 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2618,7 +2823,16 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-homedir@^1.0.0:
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -2666,6 +2880,10 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3009,6 +3227,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3016,6 +3238,13 @@ require-main-filename@^1.0.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3028,6 +3257,12 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rxjs@^5.0.0-beta.11:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
+  dependencies:
+    symbol-observable "^1.0.1"
 
 safe-buffer@^5.0.1:
   version "5.0.1"
@@ -3104,6 +3339,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3182,6 +3421,14 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -3209,6 +3456,14 @@ string_decoder@~1.0.0:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
   dependencies:
     buffer-shims "~1.0.0"
+
+stringify-object@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.1.tgz#2720c2eff940854c819f6ee252aaeb581f30624d"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -3240,6 +3495,10 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -3259,6 +3518,10 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -3457,7 +3720,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.10, which@^1.2.12, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@ abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
+abab@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -15,6 +19,10 @@ acorn-globals@^3.1.0:
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
     acorn "^4.0.4"
+
+acorn@^4.0.4:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^4.0.4:
   version "4.0.13"
@@ -137,6 +145,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -2352,6 +2364,10 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+longest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+
 loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -3043,6 +3059,14 @@ sax@^1.2.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+sax@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+"semver@2 || 3 || 4 || 5":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
 semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -3296,6 +3320,12 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.3:
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@^2.3.2, tough-cookie@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,6 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assertion-error@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
-
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -1124,14 +1120,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
-  dependencies:
-    assertion-error "^1.0.1"
-    deep-eql "^0.1.3"
-    type-detect "^1.0.0"
-
 chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1298,12 +1286,6 @@ debug@^2.6.3, debug@^2.6.8:
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-deep-eql@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
-  dependencies:
-    type-detect "0.1.1"
 
 deep-extend@~0.4.0:
   version "0.4.1"
@@ -1544,12 +1526,6 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
-  dependencies:
-    samsam "~1.1"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -1803,10 +1779,6 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 ini@~1.3.0:
   version "1.3.4"
@@ -2375,10 +2347,6 @@ locate-path@^2.0.0:
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3053,10 +3021,6 @@ safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
-
 sane@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.2.0.tgz#d6d2e2fcab00e3d283c93b912b7c3a20846f1d56"
@@ -3112,15 +3076,6 @@ shellwords@^0.1.0:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-sinon@^1.17.3:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
-  dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3368,14 +3323,6 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
-
-type-detect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
-
 ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
@@ -3404,12 +3351,6 @@ user-home@^1.1.1:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 uuid@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-escapes@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -84,6 +88,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -1132,7 +1140,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.0, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1142,7 +1150,7 @@ chalk@^1.1.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1:
+chalk@^2.0.1, chalk@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
@@ -1168,6 +1176,23 @@ chokidar@^1.6.1:
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+
+cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1215,6 +1240,10 @@ commander@^2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1246,6 +1275,19 @@ core-js@^2.5.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1282,6 +1324,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.3"
@@ -1336,6 +1382,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -1408,6 +1458,22 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -1474,6 +1540,13 @@ fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1594,6 +1667,10 @@ gauge@~2.7.1:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1769,6 +1846,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -1780,6 +1865,16 @@ iconv-lite@~0.4.13:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1850,6 +1945,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1872,11 +1971,21 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -1885,6 +1994,14 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -2196,7 +2313,7 @@ jest-util@^21.2.1:
     jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
-jest-validate@^21.2.1:
+jest-validate@^21.1.0, jest-validate@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
   dependencies:
@@ -2225,7 +2342,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2330,6 +2447,72 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lint-staged@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.3.tgz#5a1f12256af06110b96225f109dbf215009a37a9"
+  dependencies:
+    app-root-path "^2.0.0"
+    chalk "^2.1.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.8.0"
+    is-glob "^4.0.0"
+    jest-validate "^21.1.0"
+    listr "^0.12.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    staged-git-files "0.0.4"
+    stringify-object "^3.2.0"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2359,6 +2542,25 @@ locate-path@^2.0.0:
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.1.0.tgz#f35fa60e278832b538dc4dddcbb478a45d3e3be6"
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2550,17 +2752,35 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.0.2"
@@ -2583,7 +2803,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2599,6 +2819,10 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2618,7 +2842,16 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-homedir@^1.0.0:
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -2666,6 +2899,10 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -2755,6 +2992,10 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 pretty-format@^21.2.1:
   version "21.2.1"
@@ -3009,6 +3250,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3016,6 +3261,13 @@ require-main-filename@^1.0.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3028,6 +3280,12 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rxjs@^5.0.0-beta.11:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
+  dependencies:
+    symbol-observable "^1.0.1"
 
 safe-buffer@^5.0.1:
   version "5.0.1"
@@ -3104,6 +3362,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3182,6 +3444,14 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -3209,6 +3479,14 @@ string_decoder@~1.0.0:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
   dependencies:
     buffer-shims "~1.0.0"
+
+stringify-object@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.1.tgz#2720c2eff940854c819f6ee252aaeb581f30624d"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -3240,6 +3518,10 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -3259,6 +3541,10 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -3457,7 +3743,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.10, which@^1.2.12, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
**Note** this was closed and re-opened because of an issue with a merge. 

As I was working on Jest test conversions I noticed small little inconsistencies with conventions so this PR is adding [Prettier](https://www.npmjs.com/package/prettier) as a `precommit` hook. 

The way it works is any `js,json` files that are staged will have prettier on them applied right before `git commit` is ran. It will clean up any small syntax issues to enforce a consistent convention. I set the pretty flags to my personal preference however that can be updated easily. 

Prettier setup: 
```
prettier --write --trailing-comma es5 --single-quote --tab-width 2
``` 

* Trailing commas in objects not functions. 
* single quote for arguments.
* tab width set to 2 spaces.

I would suggest getting a prettier package for whichever editor you are using and put `Format on save` on, however this will catch changes going forward. 

All current `.js, .json` files have been prettiered. 

**Note** Once #6 is merged this PR will be easier to remove. 

Closes #8 